### PR TITLE
Version update to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Installation
 
 Install the library by adding it to your ``composer.json`` or running::
 
-  php composer.phar require crate/crate-dbal:~0.0.5
+  php composer.phar require crate/crate-dbal:~0.2.0
 
 Configuration
 -------------
@@ -133,4 +133,3 @@ For a more detailed configuration please refer to the `Doctrine ORM`_ documentat
 .. _`Crate`: https://crate.io
 .. _`Doctrine ORM`: http://doctrine-orm.readthedocs.org/en/latest/reference/configuration.html
 .. _`DQL`: http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
-


### PR DESCRIPTION
I flagged the same issue in the pdo driver (https://github.com/crate/crate-pdo/pull/25) telling users to use an old version causes errors when running `composer install`, changing instructions to use the latest version clears these problems.