### PR TITLE
enabled sitemap generation through sphinx module in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,3 +12,6 @@ html_theme_options.update({
     'canonical_url_path': 'docs/reference/dbal/',
     'tracking_project': 'crate-dbal',
 })
+
+site_url = 'https://crate.io/docs/clients/dbal/en/latest/'
+extensions = ['sphinx_sitemap']


### PR DESCRIPTION
* added extension to `docs/conf.py`
* set base url in `docs/conf.py`
* this will automatically generate a sitemap for every docs build