### PR TITLE
fixes license identifier according to https://spdx.org/licenses/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "crate/crate-dbal",
     "description": "A Doctrine Database Abstraction Layer for the Crate.io DBMS",
-    "license": "Apache2",
+    "license": "Apache-2.0",
     "homepage": "https://github.com/crate/crate-dbal",
     "keywords": ["database", "dbal", "doctrine", "crate"],
     "minimum-stability": "dev",


### PR DESCRIPTION
running `composer validate` resulted in a warning about an invalid license identifier.