### PR TITLE
fixes phpunit test runs inside vagrant

### DIFF
--- a/provisioning.sh
+++ b/provisioning.sh
@@ -12,4 +12,6 @@ deb https://cdn.crate.io/downloads/deb/stable/ trusty main
 deb-src https://cdn.crate.io/downloads/deb/stable/ trusty main
 EOT
 apt-get update
-apt-get install -y crate php7.2-cli php7.2-xml php7.2-curl php7.2-mbstring
+apt-get install -y crate php7.2-cli php7.2-xml php7.2-curl php7.2-mbstring git zip unzip
+curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+cd /vagrant && su vagrant -c 'composer install'

--- a/provisioning.sh
+++ b/provisioning.sh
@@ -15,3 +15,5 @@ apt-get update
 apt-get install -y crate php7.2-cli php7.2-xml php7.2-curl php7.2-mbstring git zip unzip
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 cd /vagrant && su vagrant -c 'composer install'
+// test classes of DBAL which we depend on are only available inside the source
+cd /vagrant && su vagrant -c 'rm -rf vendor/doctrine/dbal && composer update doctrine/dbal --prefer-source'


### PR DESCRIPTION
adds composer and php dependencies installation to vagrant provisioning
- install packages `git`,`zip` and `upzip` required by `composer`.
- install latest `composer` binary into global path.

vagrant: install `doctrine/dbal` dependency from source.
The distribution of `doctrine/dbal` is missing the required
test base classes `crate-dbal` is relying on.