### PR TITLE
Add support for CrateDB specific table options

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+- Added support for CrateDB specific table options incl. usage documentation.
+
 2019/08/20 2.0.0
 ================
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2",
-        "doctrine/dbal": "^2.9",
+        "doctrine/dbal": "~2.9.2",
         "crate/crate-pdo": "^1.0.0"
     },
     "autoload": {

--- a/docs/appendices/index.rst
+++ b/docs/appendices/index.rst
@@ -11,5 +11,6 @@ Supplementary information for the CrateDB DBAL driver.
 .. toctree::
    :maxdepth: 2
 
+   table-options
    data-types
    compatibility

--- a/docs/appendices/table-options.rst
+++ b/docs/appendices/table-options.rst
@@ -1,0 +1,74 @@
+.. _table-options:
+
+================================
+ CrateDB specific table options
+================================
+
+CrateDB supports a custom ``CREATE TABLE`` syntax for adjusting the table
+configuration incl. ``SHARDING`` and ``PARTITIONING`` of the table.
+See `CrateDB CREATE TABLE Documentation`_ for all supported configuration
+options.
+
+All CrateDB specific table options must be passed in using the ``$options``
+argument of the DBAL ``Table()`` constructor.
+
+Example:
+
+.. code-block:: php
+
+   $options = [];
+   $options['sharding_shards'] = 5;
+   $myTable = new Table('my_table', [], [], [], 0, $options);
+
+
+Sharding Options
+================
+
+Following table options can used to adjust the sharding of a table.
+See also `CrateDB Sharding Documentation`_.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - ``$options['sharding_num_shards']``
+     - Specifies the number of shards a table is stored in. Must be greater than 0.
+   * - ``$options['sharding_routing_column']``
+     - Allows to explicitly specify a column or field on which rows are sharded by.
+
+
+Partitioning Options
+====================
+
+Following table options can used to define the partitioning columns of a table.
+See also `CrateDB Partitioned Tables Documentation`_.
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - ``$options['partition_columns']``
+     - Specifies the columns on which partitions should be created on.
+
+General Options
+===============
+
+All general CrateDB specific table options used inside the ``WITH (...)`` clause
+can be configured under the ``table_options`` option key.
+
+Example on how to adjust the replicas:
+
+.. code-block:: php
+
+   $options = [];
+   $options['table_options'] = [];
+   $options['table_options']['number_of_replicas'] = '2';
+   $myTable = new Table('my_table', [], [], [], 0, $options);
+
+
+.. _CrateDB CREATE TABLE Documentation: https://crate.io/docs/crate/reference/en/latest/sql/statements/create-table.html
+.. _CrateDB Sharding Documentation: https://crate.io/docs/crate/reference/en/latest/general/ddl/sharding.html
+.. _CrateDB Partitioned Tables Documentation: https://crate.io/docs/crate/reference/en/latest/general/ddl/partitioned-tables.html

--- a/docs/buildout.cfg
+++ b/docs/buildout.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.org/simple/
 extends = versions.cfg
 versions = versions
 show-picked-versions = true

--- a/docs/versions.cfg
+++ b/docs/versions.cfg
@@ -2,12 +2,12 @@
 Babel = 2.2.0
 Jinja2 = 2.8
 Pygments = 2.0.2
-Sphinx = 1.3.4
+Sphinx = 1.7.4
 alabaster = 0.7.7
-crate-docs-theme = 0.4.3
+crate-docs-theme = 0.7.1
 docutils = 0.12
 pytz = 2015.7
-setuptools = 19.2
+setuptools = 41.6.0
 six = 1.10.0
 snowballstemmer = 1.2.1
 sphinx-rtd-theme = 0.1.9
@@ -17,7 +17,3 @@ zc.recipe.egg = 2.0.3
 # Required by:
 # Jinja2==2.8
 MarkupSafe = 0.23
-
-# Required by:
-# crate-docs-theme==0.4.3
-sphinxcontrib-plantuml = 0.6

--- a/test/Crate/Test/DBAL/Functional/TableOptionsTest.php
+++ b/test/Crate/Test/DBAL/Functional/TableOptionsTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Licensed to CRATE Technology GmbH("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+namespace Crate\Test\DBAL\Functional;
+
+
+use Crate\DBAL\Platforms\CratePlatform;
+use Crate\Test\DBAL\DBALFunctionalTestCase;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Schema\Table;
+use InvalidArgumentException;
+
+class TableOptionsTest extends DBALFunctionalTestCase {
+
+    public function testAdditionalTableOptions()
+    {
+        $platform = $this->_conn->getDatabasePlatform();
+
+        $options = [];
+        $options['sharding_routing_column'] = 'id';
+        $options['sharding_num_shards'] = 6;
+        $options['partition_columns'] = ['parted', 'date'];
+        $options['table_options'] = [];
+        $options['table_options']['number_of_replicas'] = '0-2';
+        $options['table_options']['write.wait_for_active_shards'] = 'ALL';
+
+        $table = new Table('t1', [], [], [], 0, $options);
+        $table->addColumn('id', 'integer');
+        $table->addColumn('parted', 'integer');
+        $table->addColumn('date', 'timestamp');
+
+        $sql = $platform->getCreateTableSQL($table);
+        $this->assertEquals(array(
+                'CREATE TABLE t1 (id INTEGER, parted INTEGER, date TIMESTAMP)'
+                . ' CLUSTERED BY (id) INTO 6 SHARDS'
+                . ' PARTITIONED BY (parted, date)'
+                . ' WITH ("number_of_replicas" = \'0-2\', "write.wait_for_active_shards" = \'ALL\')')
+                , $sql);
+    }
+
+    public function testPartitionColumnsNotArray()
+    {
+        $platform = $this->_conn->getDatabasePlatform();
+
+        $options = [];
+        $options['partition_columns'] = 'parted';
+        $table = new Table('t1', [], [], [], 0, $options);
+        $table->addColumn('parted', 'integer');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Expecting array type at 'partition_columns'");
+        $platform->getCreateTableSQL($table);
+    }
+}


### PR DESCRIPTION
CrateDB supports some specific table options e.g. for configuring
sharding, partitioned tables or number of replicas.
Passing this configurations via DBAL `$options` is now possible.

Relates #75.