### PR TITLE
Fix handling of PRIMARY KEY constraints 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+- Fixed handling of ``PRIMARY KEY`` contraints.
+  Tables *without* any PK raised an exception while reading, on Tables
+  *with* any PK, the constraints weren't read/processed correctly.
+
 - Added support for CrateDB specific table options incl. usage documentation.
 
 2019/08/20 2.0.0

--- a/src/Crate/DBAL/Platforms/CratePlatform1.php
+++ b/src/Crate/DBAL/Platforms/CratePlatform1.php
@@ -55,4 +55,15 @@ class CratePlatform1 extends CratePlatform
         return "SELECT constraint_name, constraint_type from information_schema.table_constraints " .
             "WHERE table_name = '$t[1]' AND table_schema = '$t[0]' AND constraint_type = 'PRIMARY KEY'";
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    {
+        $t = $this->tableAndSchema($table);
+        return "SELECT c.constraint_name, c.constraint_type, k. column_name from information_schema.table_constraints c " .
+                "JOIN information_schema.key_column_usage k on c.constraint_name = k.constraint_name " .
+                "WHERE c.table_name = '$t[1]' AND c.table_schema = '$t[0]'";
+    }
 }

--- a/src/Crate/DBAL/Platforms/CratePlatform1.php
+++ b/src/Crate/DBAL/Platforms/CratePlatform1.php
@@ -25,6 +25,8 @@ namespace Crate\DBAL\Platforms;
 
 class CratePlatform1 extends CratePlatform
 {
+    const TABLE_WHERE_CLAUSE_FORMAT_1 = '%s.table_name = %s AND %s.table_schema = %s';
+
     /**
      * {@inheritDoc}
      */
@@ -37,33 +39,8 @@ class CratePlatform1 extends CratePlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    protected function getTableWhereClauseFormat()
     {
-        $t = $this->tableAndSchema($table);
-        // todo: make safe
-        return "SELECT * from information_schema.columns " .
-            "WHERE table_name = '$t[1]' AND table_schema = '$t[0]'";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getListTableConstraintsSQL($table, $database = null)
-    {
-        $t = $this->tableAndSchema($table);
-        // todo: make safe
-        return "SELECT constraint_name, constraint_type from information_schema.table_constraints " .
-            "WHERE table_name = '$t[1]' AND table_schema = '$t[0]' AND constraint_type = 'PRIMARY KEY'";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
-    {
-        $t = $this->tableAndSchema($table);
-        return "SELECT c.constraint_name, c.constraint_type, k. column_name from information_schema.table_constraints c " .
-                "JOIN information_schema.key_column_usage k on c.constraint_name = k.constraint_name " .
-                "WHERE c.table_name = '$t[1]' AND c.table_schema = '$t[0]'";
+        return self::TABLE_WHERE_CLAUSE_FORMAT_1;
     }
 }


### PR DESCRIPTION
The SchemaManager raised an exception while reading tables *without*
any PRIMARY KEY constraints and ignored them when existing.

Relates #75.