### PR TITLE
Add support for `DEFAULT` column clause

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,11 +5,20 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
-- Fixed handling of ``PRIMARY KEY`` contraints.
+Changes
+-------
+
+- Added support for ``DEFAULT`` column clause.
+
+- Added support for CrateDB specific table options incl. usage documentation.
+
+Fixes
+-----
+
+- Fixed handling of ``PRIMARY KEY`` and ``NOT NULL`` contraints.
   Tables *without* any PK raised an exception while reading, on Tables
   *with* any PK, the constraints weren't read/processed correctly.
 
-- Added support for CrateDB specific table options incl. usage documentation.
 
 2019/08/20 2.0.0
 ================

--- a/src/Crate/DBAL/Platforms/CratePlatform4.php
+++ b/src/Crate/DBAL/Platforms/CratePlatform4.php
@@ -23,6 +23,10 @@
 namespace Crate\DBAL\Platforms;
 
 
+use Crate\DBAL\Types\TimestampType;
+use Doctrine\DBAL\Types\BooleanType;
+use Doctrine\DBAL\Types\PhpIntegerMappingType;
+
 class CratePlatform4 extends CratePlatform1
 {
     /**
@@ -90,5 +94,37 @@ class CratePlatform4 extends CratePlatform1
     public function getClobTypeDeclarationSQL(array $field)
     {
         return 'TEXT';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultValueDeclarationSQL($field)
+    {
+        if (! isset($field['default'])) {
+            return '';
+        }
+
+        $default = $field['default'];
+
+        if (! isset($field['type'])) {
+            return " DEFAULT '" . $default . "'";
+        }
+
+        $type = $field['type'];
+
+        if ($type instanceof PhpIntegerMappingType) {
+            return ' DEFAULT ' . $default;
+        }
+
+        if ($type instanceof TimestampType) {
+            return ' DEFAULT ' . $default;
+        }
+
+        if ($type instanceof BooleanType) {
+            return " DEFAULT '" . $this->convertBooleans($default) . "'";
+        }
+
+        return " DEFAULT '" . $default . "'";
     }
 }

--- a/src/Crate/DBAL/Schema/CrateSchemaManager.php
+++ b/src/Crate/DBAL/Schema/CrateSchemaManager.php
@@ -60,6 +60,9 @@ class CrateSchemaManager extends AbstractSchemaManager
         if (!isset($tableColumn['is_nullable'])) {
             $tableColumn['is_nullable'] = true;
         }
+        if (!isset($tableColumn['column_default'])) {
+            $tableColumn['column_default'] = null;
+        }
 
         $dbType = strtolower($tableColumn['data_type']);
         $type = $this->_platform->getDoctrineTypeMapping($dbType);
@@ -67,7 +70,7 @@ class CrateSchemaManager extends AbstractSchemaManager
         $options = array(
             'length'        => null,
             'notnull'       => ! $tableColumn['is_nullable'],
-            'default'       => null,
+            'default'       => $tableColumn['column_default'],
             'precision'     => null,
             'scale'         => null,
             'fixed'         => null,

--- a/test/Crate/Test/DBAL/Functional/Schema/SchemaManagerTest.php
+++ b/test/Crate/Test/DBAL/Functional/Schema/SchemaManagerTest.php
@@ -257,4 +257,31 @@ class SchemaManagerTest extends DBALFunctionalTestCase
         self::assertTrue($tableIndexes['primary']->isUnique());
         self::assertTrue($tableIndexes['primary']->isPrimary());
     }
+
+    public function testColumnDefaultClause()
+    {
+        $table = new Table('t1');
+        $table->addColumn('ts', 'timestamp', array('default' => 'current_timestamp'));
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $schema = $this->_sm->createSchema();
+        $table = $schema->getTable('t1');
+
+        self::assertEquals('"current_timestamp"(3)', $table->getColumn('ts')->getDefault());
+    }
+
+    public function testColumnNotNullConstraint()
+    {
+        $table = new Table('t1');
+        // not_null is `true` by default
+        $table->addColumn('id', 'integer', array('notnull' => false));
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $schema = $this->_sm->createSchema();
+        $table = $schema->getTable('t1');
+
+        self::assertFalse($table->getColumn('id')->getNotnull());
+    }
 }

--- a/test/Crate/Test/DBAL/Functional/Schema/SchemaManagerTest.php
+++ b/test/Crate/Test/DBAL/Functional/Schema/SchemaManagerTest.php
@@ -270,18 +270,4 @@ class SchemaManagerTest extends DBALFunctionalTestCase
 
         self::assertEquals('"current_timestamp"(3)', $table->getColumn('ts')->getDefault());
     }
-
-    public function testColumnNotNullConstraint()
-    {
-        $table = new Table('t1');
-        // not_null is `true` by default
-        $table->addColumn('id', 'integer', array('notnull' => false));
-
-        $this->_sm->dropAndCreateTable($table);
-
-        $schema = $this->_sm->createSchema();
-        $table = $schema->getTable('t1');
-
-        self::assertFalse($table->getColumn('id')->getNotnull());
-    }
 }

--- a/test/Crate/Test/DBAL/Platforms/CratePlatformTest.php
+++ b/test/Crate/Test/DBAL/Platforms/CratePlatformTest.php
@@ -503,4 +503,20 @@ class CratePlatformTest extends AbstractPlatformTestCase {
     {
         $this->markTestSkipped('Platform does not support TRUNCATE TABLE.');
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function testGetDefaultValueDeclarationSQLDateTime() : void
+    {
+        $this->markTestSkipped('Platform does not support DateTime types, use Timestamp instead.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testGetDefaultValueDeclarationSQLForDateType() : void
+    {
+        $this->markTestSkipped('Platform does not support Date types, use Timestamp instead.');
+    }
 }


### PR DESCRIPTION
`DEFAULT` is only supported on CrateDB > 4.x.
