### PR TITLE
Fix tests related to dbal 2.10 and flaky ordering

### DIFF
--- a/test/Crate/Test/DBAL/Functional/DataAccessTest.php
+++ b/test/Crate/Test/DBAL/Functional/DataAccessTest.php
@@ -25,6 +25,7 @@ namespace Crate\Test\DBAL\Functional;
 use Crate\DBAL\Types\MapType;
 use Crate\Test\DBAL\DBALFunctionalTestCase;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Connection;
@@ -212,7 +213,7 @@ class DataAccessTestCase extends DBALFunctionalTestCase
         $paramStr = 'foo';
 
         $sql = "SELECT test_int, test_string FROM " . $this->_conn->quoteIdentifier($table) . " ".
-               "WHERE test_int = " . $this->_conn->quote($paramInt) . " AND test_string = " . $this->_conn->quote($paramStr);
+               "WHERE test_int = " . $this->_conn->quote($paramInt, ParameterType::INTEGER) . " AND test_string = '" . $paramStr . "')";
         $stmt = $this->_conn->prepare($sql);
         $this->assertInstanceOf('Doctrine\DBAL\Statement', $stmt);
     }
@@ -403,7 +404,7 @@ class DataAccessTestCase extends DBALFunctionalTestCase
     {
         $this->expectException(DBALException::class);
 
-        $sql = "SELECT * FROM fetch_table WHERE test_string = " . $this->_conn->quote("bar' OR '1'='1");
+        $sql = "SELECT * FROM fetch_table WHERE test_string = bar' OR '1'='1";
         $this->_conn->fetchAll($sql);
     }
 

--- a/test/Crate/Test/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/test/Crate/Test/DBAL/Functional/ModifyLimitQueryTest.php
@@ -107,7 +107,7 @@ class ModifyLimitQueryTest extends DBALFunctionalTestCase
 
         $this->refresh('modify_limit_table2');
 
-        $sql = "SELECT test_int FROM modify_limit_table2 GROUP BY test_int";
+        $sql = "SELECT test_int FROM modify_limit_table2 GROUP BY test_int order by test_int";
         $this->assertLimitResult(array(1, 2), $sql, 10, 0);
         $this->assertLimitResult(array(1), $sql, 1, 0);
         $this->assertLimitResult(array(2), $sql, 1, 1);


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Since DBAL 2.10, $conn->quote is using the driver’s connection->quote
correctly but Crate-PDO does not support quoting of strings by intent.

The other failing test was flaky cause of a missing ordering clause.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
