### PR TITLE
Implement list table details to include specific CrateDB table options

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+- Added support for CrateDB specific table options when retrieving table information
+  from the schema manager.
+
 2020/01/08 2.2.0
 ================
 

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -36,7 +36,7 @@ If you plan to query CrateDB via DBAL, you can get a connection from the
 
     $params = array(
         'driverClass' => 'Crate\DBAL\Driver\PDOCrate\Driver',
-        'user' => 'crate'
+        'user' => 'crate',
         'host' => 'localhost',
         'port' => 4200
     );

--- a/src/Crate/DBAL/Platforms/CratePlatform.php
+++ b/src/Crate/DBAL/Platforms/CratePlatform.php
@@ -840,4 +840,17 @@ class CratePlatform extends AbstractPlatform
     {
         throw DBALException::notSupported(__METHOD__);
     }
+
+    /**
+     * Returns the SQL query to return the CrateDB specific table options associated
+     * with a given table.
+     *
+     * @return string
+     */
+    public function getTableOptionsSQL(string $table) : string
+    {
+        return "SELECT clustered_by, number_of_shards, partitioned_by, number_of_replicas, column_policy, settings " .
+		"FROM information_schema.tables c " .
+		"WHERE " . $this->getTableWhereClause($table);
+    }
 }


### PR DESCRIPTION
This should address #84.

When using ``getOptions()`` with a Table that was retrieved from the schema manager, the driver will now load the Table's options, such as sharding and partition information.

```
<?php
use Doctrine\DBAL\Schema\Table;

$params = array(
    'driverClass' => 'Crate\DBAL\Driver\PDOCrate\Driver',
    'user' => 'crate',
    'host' => 'localhost',
    'port' => 4200
);
$connection = \Doctrine\DBAL\DriverManager::getConnection($params);
$schemaManager = $connection->getSchemaManager();
$platform = $connection->getDatabasePlatform();


$options = [];
$options['sharding_routing_column'] = 'id';
$options['sharding_num_shards'] = 6;
$options['partition_columns'] = ['parted', 'date'];
$options['table_options'] = [];
$options['table_options']['number_of_replicas'] = '0-2';
$options['table_options']['write.wait_for_active_shards'] = 'ALL';

$table = new Table('mytable', [], [], [], 0, $options);
$table->addColumn('id', 'integer');
$table->addColumn('parted', 'integer');
$table->addColumn('date', 'timestamp');

$schema = $schemaManager->createSchema();

foreach ($schema->getTables() as $table) {
	print_r($table->getOptions());
}

```

Results in:

```
Array
(
    [create_options] => Array
        (
        )

    [sharding_routing_column] => id
    [sharding_num_shards] => 6
    [partition_columns] => Array
        (
            [0] => parted
            [1] => date
        )

    [table_options] => Array
        (
            [codec] => default
            [routing.allocation.include] => 
            [routing.allocation.require] => 
            [routing.allocation.exclude] => 
            [routing.allocation.enable] => all
            [routing.allocation.total_shards_per_node] => -1
            [mapping.total_fields.limit] => 1000
            [refresh_interval] => 1000
            [translog.flush_threshold_size] => 536870912
            [translog.sync_interval] => 5000
            [translog.durability] => REQUEST
            [blocks.metadata] => 
            [blocks.read] => 
            [blocks.read_only] => 
            [blocks.write] => 
            [merge.scheduler.max_thread_count] => 
            [merge.scheduler.max_merge_count] => 
            [store.type] => fs
            [unassigned.node_left.delayed_timeout] => 60000
            [write.wait_for_active_shards] => ALL
            [warmer.enabled] => 1
            [number_of_replicas] => 0-2
            [column_policy] => strict
        )

)
```
