### PR TITLE
Pin doctrine-dbal to v2.9.x to avoid any breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2",
-        "doctrine/dbal": "^2.9",
+        "doctrine/dbal": "~2.9.0",
         "crate/crate-pdo": "^1.0.0"
     },
     "autoload": {


### PR DESCRIPTION
The test build failed cause the current dbal versioning allowed
to use doctrine-dbal 2.10.x which has breaking test suite changes.

Supersedes #90.