### PR TITLE
Rename default branch to "main"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   tests:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,6 +5,6 @@ Contributing
 Thank you for your interest in contributing.
 
 Please see the CrateDB `contribution guide`_ for more information. Everything in
-the CrateDB contribution guide applies to this repository.
+the CrateDB contribution guide also applies to this repository.
 
 .. _contribution guide: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst

--- a/README.rst
+++ b/README.rst
@@ -6,15 +6,15 @@ CrateDB DBAL Driver
     :target: https://github.com/crate/crate-dbal/actions?workflow=Tests
     :alt: Build status
 
-.. image:: https://coveralls.io/repos/github/crate/crate-dbal/badge.svg?branch=master
-    :target: https://coveralls.io/github/crate/crate-dbal?branch=master
+.. image:: https://coveralls.io/repos/github/crate/crate-dbal/badge.svg?branch=main
+    :target: https://coveralls.io/github/crate/crate-dbal?branch=main
     :alt: Coverage
 
-.. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/coverage.png?b=master
+.. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/coverage.png?b=main
     :target: https://scrutinizer-ci.com/g/crate/crate-dbal
     :alt: Coverage
 
-.. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/quality-score.png?b=master
+.. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/quality-score.png?b=main
     :target: https://scrutinizer-ci.com/g/crate/crate-dbal
     :alt: Quality
 

--- a/docs/appendices/data-types.rst
+++ b/docs/appendices/data-types.rst
@@ -108,9 +108,9 @@ via calls to the the use of the ``Column`` class and calls to the
    The Doctrine `ORM documentation`_ has more about type mapping.
 
 .. _array: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#array
-.. _ArrayType: https://github.com/crate/crate-dbal/blob/master/src/Crate/DBAL/Types/ArrayType.php
-.. _MapType: https://github.com/crate/crate-dbal/blob/master/src/Crate/DBAL/Types/MapType.php
+.. _ArrayType: https://github.com/crate/crate-dbal/blob/main/src/Crate/DBAL/Types/ArrayType.php
+.. _MapType: https://github.com/crate/crate-dbal/blob/main/src/Crate/DBAL/Types/MapType.php
 .. _object: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#object
 .. _ORM documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/basic-mapping.html
-.. _timestamp: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#timestamp
-.. _TimestampType: https://github.com/crate/crate-dbal/blob/master/src/Crate/DBAL/Types/TimestampType.php
+.. _timestamp: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#date-time-types
+.. _TimestampType: https://github.com/crate/crate-dbal/blob/main/src/Crate/DBAL/Types/TimestampType.php


### PR DESCRIPTION
This patch accompanies the adjustment of the main branch of this repository to be now called "main".