### PR TITLE
CI: Slightly adjust GHA and Scrutinizer configuration settings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ] #, macos-latest, windows-latest ]
-        php-version: [ "7.2", "7.3", "7.4" ]
+        php-version: [ '7.2', '7.3', '7.4' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
@@ -55,6 +55,7 @@ jobs:
 
       # https://github.com/php-coveralls/php-coveralls#github-actions
       - name: Upload coverage results to Coveralls
+        if: matrix.php-version == '7.4'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -62,6 +63,7 @@ jobs:
           php-coveralls --coverage_clover=build/logs/clover.xml -v
 
       - name: Upload coverage results to Scrutinizer CI
+        if: matrix.php-version == '7.4'
         run: |
           composer global require scrutinizer/ocular
           ocular code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,7 +2,8 @@ before_commands:
     - "composer install --dev --prefer-source"
 
 tools:
-    external_code_coverage: true
+    external_code_coverage:
+        enabled: true
     php_code_sniffer:
         enabled: true
         config:

--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,13 @@ CrateDB DBAL Driver
     :target: https://coveralls.io/github/crate/crate-dbal?branch=main
     :alt: Coverage
 
-.. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/coverage.png?b=main
-    :target: https://scrutinizer-ci.com/g/crate/crate-dbal
-    :alt: Coverage
-
 .. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/quality-score.png?b=main
     :target: https://scrutinizer-ci.com/g/crate/crate-dbal
     :alt: Quality
+
+.. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/coverage.png?b=main
+    :target: https://scrutinizer-ci.com/g/crate/crate-dbal
+    :alt: Coverage
 
 |
 


### PR DESCRIPTION
- GHA: Submit code coverage reports only once
- Scrutinizer CI: Allow more time for waiting on code coverage reports