### PR TITLE
CI: Disable Copy/Paste Detector in favor of Code Similarity Analyzer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,8 @@ jobs:
       # https://github.com/marketplace/actions/setup-php-action#cache-composer-dependencies
       - name: Get composer cache directory
         id: composer-cache-dir
-        run: echo "::set-output name=dir::$(composer config cache-dir)"
-      - name: Cache dependencies
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Apply dependency caching
         id: composer-cache
         uses: actions/cache@v2
         with:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,14 +4,17 @@ before_commands:
 tools:
     external_code_coverage:
         enabled: true
+        timeout: 600
     php_code_sniffer:
         enabled: true
         config:
             standard: PSR2
         filter:
             paths: ["src/*"]
-    php_cpd:
+    php_sim:
         enabled: true
+    php_cpd:
+        enabled: false
         excluded_dirs: ["build/*", "test", "vendor"]
     php_cs_fixer:
         enabled: true


### PR DESCRIPTION
This patch tries to improve the behavior on CI.

1. Fix GHA dependency caching
2. Scrutinizer yelled
```
+==================================================================================+
| PHP Copy/Paste Detector and PHP Code Similarity Analyzer cannot both be used at |
| the same time. Please remove either one, f.e. by adding 'php_cpd: false'.       |
+=================================================================================+
```

Background: There is a new (2014 already, see [1]) Code Similarity Analyzer we are switching to now.

> In PHP, Copy/Paste Detector so far could be used for detecting code clones. On Scrutinizer, it was enabled by default on all PHP projects. PHP Copy/Paste Detector operates on the token stream which is generated by PHP’s token_get_all function and uses string hashing techniques to find duplicates. This makes it quite good at detecting large literal code duplications. However, often developers modify copy/pasted code slightly which could then not be detected anymore.
> 
> To overcome the current shortcomings, we are happy to introduce a new tool for duplicated code detection, PHP Similarity Analyzer. PHP Similarity Analyzer is based on latest academic research combined with our in-depth practical experience. It has been evaluated against a range of open-source and closed-source projects and its results are already very promising. In contrast to PHP Copy/Paste Detector, it is robust against code modification and also finds smaller code fragments which make very good targets for refactoring. Besides, it not only detects copy/pasted code, but also semantically similar code.

[1] https://scrutinizer-ci.com/blog/introducing-new-duplicated-code-detection-for-php
