### PR TITLE
Update and fix environment and documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,12 @@
 name: Docs
 on:
+  workflow_dispatch:
   pull_request: ~
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 7 * * *'
 
 jobs:
   documentation:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,11 +15,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+
+      - name: Acquire sources
+        uses: actions/checkout@v2
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.7
+
       - name: Build docs
         run: |
           cd docs && make check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Acquire sources
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -51,24 +53,21 @@ jobs:
         run: composer install --prefer-source
 
       - name: Run code style checks
-        run: composer run style
+        run: composer run check-style
 
       - name: Run tests
         run: composer run test
 
-      # https://github.com/php-coveralls/php-coveralls#github-actions
-      - name: Upload coverage results to Coveralls
-        if: matrix.php-version == '7.4'
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Git HEAD ref:"
-          git log --pretty=%P -n1 HEAD
-          composer global require php-coveralls/php-coveralls
-          php-coveralls --coverage_clover=build/logs/clover.xml -v
+      # https://github.com/codecov/codecov-action
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@v1
+        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
+        with:
+          files: ./build/logs/clover.xml
+          fail_ci_if_error: true
 
       - name: Upload coverage results to Scrutinizer CI
-        if: matrix.php-version == '7.4'
+        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
         run: |
           composer global require scrutinizer/ocular
           ocular code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -39,4 +39,10 @@ build:
 
 # https://scrutinizer-ci.com/docs/tools/external-code-coverage/
 tools:
-  external_code_coverage: true
+  external_code_coverage:
+
+    enabled: true
+
+    # Scrutinizer will wait for two code coverage submissions
+    # in order to cover both PHP7 and PHP8.
+    runs: 2

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -44,10 +44,10 @@ You can run the tests like::
     composer run test
 
     # Run code style checks
-    composer run style
+    composer run check-style
 
-    # Run code style checks
-    $ ./vendor/bin/phpcs ./src
+    # Some code style quirks can be automatically fixed
+    composer run fix-style
 
 
 
@@ -55,21 +55,31 @@ You can run the tests like::
 Using Docker
 ************
 
+
 Installation
 ============
 
 Install prerequisites::
 
-    brew install php@7.2 composer
+    # Install different PHP releases.
+    brew install php@7.3 php@7.4 php@8.0 brew-php-switcher composer
+
+    # Select PHP version.
+    brew-php-switcher 7.3
+    brew-php-switcher 7.4
+    brew-php-switcher 8.0
+
+    # Install xdebug extension for tracking code coverage.
     pecl install xdebug
 
 Get the sources::
 
     git clone git@github.com:crate/crate-dbal.git
+    cd crate-dbal
 
-Setup environment::
+Setup project dependencies::
 
-    composer install --prefer-source
+    composer install
 
 
 Running the Tests

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ CrateDB DBAL Driver
     :target: https://github.com/crate/crate-dbal/actions?workflow=Docs
     :alt: Build status (documentation)
 
-.. image:: https://coveralls.io/repos/github/crate/crate-dbal/badge.svg?branch=main
-    :target: https://coveralls.io/github/crate/crate-dbal
+.. image:: https://codecov.io/gh/crate/crate-dbal/branch/main/graph/badge.svg
+    :target: https://app.codecov.io/gh/crate/crate-dbal
     :alt: Coverage
 
 .. image:: https://scrutinizer-ci.com/g/crate/crate-dbal/badges/quality-score.png?b=main
@@ -22,9 +22,13 @@ CrateDB DBAL Driver
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Latest stable version
 
-.. image:: https://poser.pugx.org/crate/crate-dbal/downloads
+.. image:: https://img.shields.io/badge/PHP-7.2%2C%207.3%2C%207.4-green.svg
     :target: https://packagist.org/packages/crate/crate-dbal
-    :alt: Total downloads
+    :alt: Supported PHP versions
+
+.. image:: https://poser.pugx.org/crate/crate-dbal/d/monthly
+    :target: https://packagist.org/packages/crate/crate-dbal
+    :alt: Monthly downloads
 
 .. image:: https://poser.pugx.org/crate/crate-dbal/license
     :target: https://packagist.org/packages/crate/crate-dbal
@@ -48,7 +52,7 @@ Installation
 
 The CrateDB PDO adapter is available as a Composer package. Install it like::
 
-    composer add crate/crate-dbal
+    composer require crate/crate-dbal
 
 See the `installation documentation`_ for more info.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+    project:
+      default:
+        target: 85%    # the required coverage value
+        threshold: 3%  # the leniency in hitting the target

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     },
     "scripts": {
         "test": "XDEBUG_MODE=coverage phpunit --coverage-clover build/logs/clover.xml",
-        "style": "phpcs"
+        "check-style": "phpcs",
+        "fix-style": "phpcbf"
     }
 }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,8 +18,58 @@
 # pursuant to the terms of the relevant commercial agreement.
 
 
-# Do not edit anything below this line
-###############################################################################
+# =============================================================================
+# Crate Docs
+# =============================================================================
+
+# The Crate Docs project provides a common set of tools for producing the
+# Crate.io documentation. See <https://github.com/crate/crate-docs/> for more
+# information.
+
+# This file is taken from the demo Sphinx project available at
+# <https://github.com/crate/crate-docs/blob/main/docs>. This demo docs project
+# provides a reference implementation that should be copied for all Sphinx
+# projects at Crate.io.
+
+# The Crate Docs build system works by centralizing its core components in the
+# `crate-docs` repository. At build time, this Makefile creates a copy of the
+# this project under the `.crate-docs` directory. This Makefile is an interface
+# for those core components.
+
+
+# Upgraded instructions
+# -----------------------------------------------------------------------------
+
+# You must pin your Sphinx project to a specific version of the Crate Docs
+# project. You can do this by editing the `build.json` file. Change the JSON
+# `message` value to the desired release number. A list of releases is
+# available at <https://github.com/crate/crate-docs/releases>.
+
+# Although care has been taken to restrict changes to the core components, you
+# may occasionally need to update your project to match the reference
+# implementation. Check the release notes for any special instructions.
+
+
+# Project-specific customization
+# =============================================================================
+
+# If you want to customize the build system for your Sphinx project, add lines
+# to this section.
+
+
+# Build system integration
+# =============================================================================
+
+# This is a boilerplate section is required for integration with the Crate Docs
+# build system. All Sphinx projects using a the same Crate Docs version
+# should have exactly the same boilerplate.
+
+# IF YOU ARE EDITING THIS FILE IN A REAL SPHINX PROJECT, YOU SHOULD NOT MAKE
+# ANY CHANGES TO THIS SECTION.
+
+# If you want to make changes to the boilerplate, please make a pull request on
+# the demo Sphinx project in the Crate Docs repository available at
+# <https://github.com/crate/crate-docs/blob/main/docs>.
 
 .EXPORT_ALL_VARIABLES:
 
@@ -27,36 +77,69 @@ DOCS_DIR      := docs
 TOP_DIR       := ..
 BUILD_JSON    := build.json
 BUILD_REPO    := https://github.com/crate/crate-docs.git
+LATEST_BUILD  := https://github.com/crate/crate-docs/releases/latest
 CLONE_DIR     := .crate-docs
-SRC_DIR       := $(CLONE_DIR)/src
-SELF_SRC      := $(TOP_DIR)/src
+SRC_DIR       := $(CLONE_DIR)/common-build
+SELF_SRC      := $(TOP_DIR)/common-build
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk
 SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
 # Parse the JSON file
-BUILD_VERSION = $(shell cat $(BUILD_JSON) | \
+BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
     python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
 
 ifeq ($(BUILD_VERSION),)
-$(error No version specified in $(BUILD_JSON))
+$(error No build version specified in `$(BUILD_JSON)`.)
+endif
+
+# This is a non-essential check so we timeout after only two seconds so as not
+# to frustrate the user when there are network issues
+LATEST_VERSION := $(shell curl -sI --connect-timeout 2 '$(LATEST_BUILD)' | \
+    grep -i 'Location:' | grep -Eoh '[^/]+$$')
+
+# Skip if no version could be determined (i.e., because of a network error)
+ifneq ($(LATEST_VERSION),)
+# Only issue a warning if there is a version mismatch
+ifneq ($(BUILD_VERSION),$(LATEST_VERSION))
+define version_warning
+You are using Crate Docs version $(BUILD_VERSION), however version \
+$(LATEST_VERSION) is available. You should consider upgrading. Follow the \
+instructions in `Makefile` and then run `make reset`.
+endef
+endif
 endif
 
 # Default rule
 .PHONY: help
 help: $(CLONE_DIR)
+	@ $(MAKE) version-warn
 	@ $(SRC_MAKE) $@
+
+.PHONY: version-warn
+version-warn:
+	@ # Because version numbers may vary in length, we must wrap the warning
+	@ # message at run time to be sure of correct output
+	@ if test -n '$(version_warning)'; then \
+	      printf '\033[33m'; \
+	      echo '$(version_warning)' | fold -w 79 -s; \
+	      printf '\033[00m\n'; \
+	  fi
 
 ifneq ($(wildcard $(SELF_MAKEFILE)),)
 # The project detects itself and fakes an install of its own core build rules
 # so that it can test itself
 $(CLONE_DIR):
-	mkdir -p $@
-	cp -R $(SELF_SRC) $(SRC_DIR)
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ mkdir -p $@
+	@ cp -R $(SELF_SRC) $(SRC_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
 else
 # All other projects install a versioned copy of the core build rules
 $(CLONE_DIR):
-	git clone --depth=1 -c advice.detachedHead=false \
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ git clone --depth=1 -c advice.detachedHead=false \
 	    --branch=$(BUILD_VERSION) $(BUILD_REPO) $(CLONE_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
 endif
 
 # Don't pass through this target
@@ -66,8 +149,11 @@ Makefile:
 # By default, pass targets through to the core build rules
 .PHONY:
 %: $(CLONE_DIR)
+	@ $(MAKE) version-warn
 	@ $(SRC_MAKE) $@
 
 .PHONY: reset
 reset:
-	rm -rf $(CLONE_DIR)
+	@ printf '\033[1mResetting the build system...\033[00m\n'
+	@ rm -rf $(CLONE_DIR)
+	@ printf 'Removed: $(CLONE_DIR)\n'

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -30,11 +30,6 @@ Consult the following table for CrateDB version compatibility notes:
 |                |                 | The default CrateDB user is ``crate`` and |
 |                |                 | has no password is set.                   |
 |                |                 |                                           |
-|                |                 | The `enterprise edition`_ of CrateDB      |
-|                |                 | allows you to `create your own users`_.   |
-|                |                 |                                           |
-|                |                 | Prior versions of CrateDB do not support  |
-|                |                 | this feature.                             |
 +----------------+-----------------+-------------------------------------------+
 | >= 1.0         | >= 2.3.x        |                                           |
 +----------------+-----------------+-------------------------------------------+
@@ -83,6 +78,4 @@ DBAL
 | >= 2.2         | Based on Doctrine 2.10                       | Supported. |
 +----------------+----------------------------------------------+------------+
 
-.. _create your own users: https://crate.io/docs/crate/reference/en/latest/admin/user-management.html
-.. _enterprise edition: https://crate.io/products/cratedb-enterprise/
 .. _query builder: https://www.doctrine-project.org/projects/doctrine-dbal/en/2.7/reference/query-builder.html#join-clauses

--- a/docs/appendices/data-types.rst
+++ b/docs/appendices/data-types.rst
@@ -30,33 +30,33 @@ This driver maps CrateDB types to the following PHP types:
    "`array`__", "`array`__"
 
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
-__ https://secure.php.net/manual/en/language.types.boolean.php
+__ https://www.php.net/manual/en/language.types.boolean.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.integer.php
+__ https://www.php.net/manual/en/language.types.integer.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.integer.php
+__ https://www.php.net/manual/en/language.types.integer.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.integer.php
+__ https://www.php.net/manual/en/language.types.integer.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.string.php
+__ https://www.php.net/manual/en/language.types.string.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.float.php
+__ https://www.php.net/manual/en/language.types.float.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.float.php
+__ https://www.php.net/manual/en/language.types.float.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-types
-__ https://secure.php.net/manual/en/language.types.string.php
+__ https://www.php.net/manual/en/language.types.string.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#ip
-__ https://secure.php.net/manual/en/language.types.string.php
+__ https://www.php.net/manual/en/language.types.string.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#date-time-types
-__ https://secure.php.net/manual/en/class.datetime.php
+__ https://www.php.net/manual/en/class.datetime.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-point
-__ https://secure.php.net/manual/en/language.types.array.php
+__ https://www.php.net/manual/en/language.types.array.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-shape
-__ https://secure.php.net/manual/en/language.types.array.php
+__ https://www.php.net/manual/en/language.types.array.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#object
-__ https://secure.php.net/manual/en/language.types.array.php
+__ https://www.php.net/manual/en/language.types.array.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#array
-__ https://secure.php.net/manual/en/language.types.array.php
+__ https://www.php.net/manual/en/language.types.array.php
 
 .. _column-type-definitions:
 

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "main"
+  "message": "2.0.0"
 }

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -22,12 +22,12 @@ The driver is available as a package at `crate/crate-dbal`_.
 
 Add the driver package to your project's `composer.json`_::
 
-    composer add crate/crate-dbal
+    composer require crate/crate-dbal
 
 If you're using `Doctrine ORM`_, you should add the ``doctrine/orm`` dependency
 too::
 
-    composer add crate/crate-dbal
+    composer require doctrine/orm
 
 
 Install


### PR DESCRIPTION
Hi,

this is a mixture of things I still had on my working tree paired with some updates similar to https://github.com/crate/crate-pdo/pull/118 and https://github.com/crate/crate-pdo/pull/119.

- Update to crate-docs 2.0.0
- Run link checker each morning
- Update some outdated links
- Use Codecov instead of Coveralls
- Update Scrutinizer configuration
- Improve README and DEVELOP documents
- Remove notes about "enterprise edition" from documentation

With kind regards,
Andreas.