### PR TITLE
Some adjustments, mostly CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -45,4 +45,4 @@ tools:
 
     # Scrutinizer will wait for two code coverage submissions
     # in order to cover both PHP7 and PHP8.
-    runs: 2
+    #runs: 2

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,5 +9,6 @@ Code Contributors
 =================
 
 Kamil Adryjanek (@kadryjanek) <kamil.adryjanek@gmail.com>
+Alexander Schranz (@alexander-schranz) <alexander@sulu.io>
 
 Note: (@user) means a github user name.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+- Dropped support for PHP 7.2, it has reached end of life
+
+- Fixed compatibility with Doctrine DBAL 2.13
+
 2020/06/18 2.3.0
 ================
 


### PR DESCRIPTION
Hi,

this patch bundles three small updates.

- CI: Don't run docs building on GHA/macOS, it is dead slow
- CI: Don't let Scrutinizer expect two coverage runs
- Update changelog re. #113

With kind regards,
Andreas.