### PR TITLE
CI: Add support for PHP8.1 and PHP8.2, and update GHA recipe versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
 
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
 
       - name: Build docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,21 @@
 name: Docs
+
 on:
-  workflow_dispatch:
-  pull_request: ~
   push:
-    branches:
-      - main
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
   schedule:
     - cron: '0 7 * * *'
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   documentation:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,19 @@
 name: Tests
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   tests:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '7.3', '7.4', '8.0' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
@@ -63,13 +63,13 @@ jobs:
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v3
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
+        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true
 
       - name: Upload coverage results to Scrutinizer CI
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
+        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
         run: |
           composer global require scrutinizer/ocular
           ocular code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
@@ -63,13 +63,13 @@ jobs:
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v3
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
+        if: always() && (matrix.php-version == '7.4' || startsWith(matrix.php-version, '8.'))
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true
 
       - name: Upload coverage results to Scrutinizer CI
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
+        if: always() && (matrix.php-version == '7.4' || startsWith(matrix.php-version, '8.'))
         run: |
           composer global require scrutinizer/ocular
           ocular code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -36,7 +36,7 @@ jobs:
           # Select PHPUnit version suitable for PHP 7.2.
           tools: composer, phpunit:^8.5
 
-      - uses: ramsey/composer-install@v1
+      - uses: ramsey/composer-install@v2
 
       # Remark: --prefer-source is needed for "Doctrine\Tests\DBAL\Platforms\AbstractPlatformTestCase"
       - name: Install doctrine/dbal from source
@@ -52,7 +52,7 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
         with:
           files: ./build/logs/clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04' ] #, macos-latest, windows-latest ]
+        os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
         php-version: [ '7.3', '7.4', '8.0' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -30,7 +30,7 @@ build:
     analysis:
       environment:
         php:
-          version: 7.4
+          version: 8.1
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
-- Added support for PHP 8.1
+- Added support for PHP 8.1 and PHP 8.2
 
 2021/04/28 3.0.0
 ================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+- Added support for PHP 8.1
+
 2021/04/28 3.0.0
 ================
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB DBAL Driver
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-7.2%2C%207.3%2C%207.4-green.svg
+.. image:: https://img.shields.io/badge/PHP-7.2%2C%207.3%2C%207.4%2C%208.0%2C%208.1-green.svg
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Supported PHP versions
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB DBAL Driver
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-7.2%2C%207.3%2C%207.4%2C%208.0%2C%208.1-green.svg
+.. image:: https://img.shields.io/badge/PHP-7.2%2C%207.3%2C%207.4%2C%208.0%2C%208.1%2C%208.2-green.svg
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Supported PHP versions
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.3|^8.0|^8.1",
+        "php": "^7.3|^8.0|^8.1|^8.2",
         "doctrine/dbal": "^2",
         "crate/crate-pdo": "^2"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3|^8.0|^8.1",
         "doctrine/dbal": "^2.12",
         "crate/crate-pdo": "^2.1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3|^8.0|^8.1",
-        "doctrine/dbal": "^2.12",
-        "crate/crate-pdo": "^2.1.2"
+        "doctrine/dbal": "^2",
+        "crate/crate-pdo": "^2"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hi there,

mainly intended to add support for PHP8.1 and PHP8.2, there are also a few other maintenance commits. See also https://github.com/crate/crate-pdo/pull/132.

- https://php.watch/versions/8.1
- https://php.watch/versions/8.2

With kind regards,
Andreas.