### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+2022/11/29 3.0.1
+================
+
 - Added support for PHP 8.1 and PHP 8.2
 
 2021/04/28 3.0.0

--- a/src/Crate/DBAL/Driver/PDOCrate/Driver.php
+++ b/src/Crate/DBAL/Driver/PDOCrate/Driver.php
@@ -30,7 +30,7 @@ use Doctrine\DBAL\VersionAwarePlatformDriver;
 
 class Driver implements \Doctrine\DBAL\Driver, VersionAwarePlatformDriver
 {
-    const VERSION = '3.0.0';
+    const VERSION = '3.0.1';
     const NAME = 'crate';
 
     private const VERSION_057 = '0.57.0';


### PR DESCRIPTION
Publishing a patch release which allows installation on PHP8.1 and PHP8.2. See also https://github.com/crate/crate-pdo/pull/134.