### PR TITLE
Drop support for PHP 7.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         if: always() && (matrix.php-version == '7.4' || startsWith(matrix.php-version, '8.'))
         with:
           files: ./build/logs/clover.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload coverage results to Scrutinizer CI
         if: always() && (matrix.php-version == '7.4' || startsWith(matrix.php-version, '8.'))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: always() && (matrix.php-version == '7.4' || startsWith(matrix.php-version, '8.'))
         with:
           files: ./build/logs/clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
         php-version: [ '8.0', '8.1', '8.2' ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php-version: [ '8.0', '8.1', '8.2' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+- Dropped support for PHP 7.x
+
 2022/11/29 3.0.1
 ================
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.3|^8.0|^8.1|^8.2",
+        "php": "^8.0|^8.1|^8.2",
         "doctrine/dbal": "^2",
         "crate/crate-pdo": "^2"
     },


### PR DESCRIPTION
## About
Drop support for PHP 7.x, it is EOL. See https://www.php.net/supported-versions.php.

## Details
Firstly, an unqualified / trial-and-error attempt to resolve GH-128.
Now, the outcome also relates to https://github.com/crate/crate-pdo/pull/152.