### PR TITLE
Chore: Add documentation section about how to release the package

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -172,6 +172,18 @@ To make changes to the RTD configuration (e.g., to activate or deactivate a
 release version), please contact the `@crate/docs`_ team.
 
 
+*********
+Releasing
+*********
+
+- Bump version number in ``src/Crate/DBAL/Driver/PDOCrate/Driver.php``
+- Edit ``CHANGES.txt`` correspondingly
+- Commit changes: ``Release x.x.x``
+- Tag repository: ``git tag x.x.x``
+- Push to GitHub: ``git push && git push --tags``
+- Verify publishing worked: https://packagist.org/packages/crate/crate-dbal
+
+
 .. _@crate/docs: https://github.com/orgs/crate/teams/docs
 .. _@crate/tech-writing: https://github.com/orgs/crate/teams/tech-writing
 .. _Composer: https://getcomposer.org


### PR DESCRIPTION
## About
The last release was slightly bumpy. This patch adds a documentation section about how to do it properly.

## References
- https://packagist.org/packages/crate/crate-dbal
