### PR TITLE
Disable leftover version chooser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,3 +5,10 @@ from pygments.lexers.web import PhpLexer
 lexers["php"] = PhpLexer(startinline=True, linenos=1)
 lexers["php-annotations"] = PhpLexer(startinline=True, linenos=1)
 # primary_domain = "php"
+
+# Disable version chooser.
+html_context.update({
+    "display_version": False,
+    "current_version": None,
+    "versions": [],
+})


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Since there are no versions of this docs repo, we might as well remove the version chooser to make space for headlines.