### PR TITLE
Chore: Fix broken links. Old DBAL docs are no longer available, use 3.0.

### DIFF
--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -78,4 +78,4 @@ DBAL
 | >= 2.2         | Based on Doctrine 2.10                       | Supported. |
 +----------------+----------------------------------------------+------------+
 
-.. _query builder: https://www.doctrine-project.org/projects/doctrine-dbal/en/2.7/reference/query-builder.html#join-clauses
+.. _query builder: https://www.doctrine-project.org/projects/doctrine-dbal/en/3.0/reference/query-builder.html#join-clauses

--- a/docs/appendices/data-types.rst
+++ b/docs/appendices/data-types.rst
@@ -111,6 +111,6 @@ via calls to the the use of the ``Column`` class and calls to the
 .. _ArrayType: https://github.com/crate/crate-dbal/blob/main/src/Crate/DBAL/Types/ArrayType.php
 .. _MapType: https://github.com/crate/crate-dbal/blob/main/src/Crate/DBAL/Types/MapType.php
 .. _object: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#object
-.. _ORM documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/basic-mapping.html
+.. _ORM documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/3.0/reference/basic-mapping.html
 .. _timestamp: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#dates-and-times
 .. _TimestampType: https://github.com/crate/crate-dbal/blob/main/src/Crate/DBAL/Types/TimestampType.php

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -97,8 +97,8 @@ your setup process.
 
 .. _database user: https://crate.io/docs/crate/reference/en/latest/admin/user-management.html
 .. _DBAL: https://www.doctrine-project.org/projects/dbal.html
-.. _DBAL documentation: https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/index.html
-.. _Doctrine provided example: https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/configuration.html#obtaining-an-entitymanager
+.. _DBAL documentation: https://www.doctrine-project.org/projects/doctrine-dbal/en/3.0/index.html
+.. _Doctrine provided example: https://www.doctrine-project.org/projects/doctrine-orm/en/3.0/reference/configuration.html#obtaining-an-entitymanager
 .. _Object-Relational Mapping: https://www.doctrine-project.org/projects/orm.html
-.. _Doctrine ORM documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/index.html
-.. _standard DBAL parameters: https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/reference/configuration.html
+.. _Doctrine ORM documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/3.0/index.html
+.. _standard DBAL parameters: https://www.doctrine-project.org/projects/doctrine-dbal/en/3.0/reference/configuration.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,10 +33,10 @@ This driver also works with `Doctrine ORM`_, an `Object-Relational Mapper`_.
    appendices/index
 
 .. _CrateDB: https://crate.io/products/cratedb/
-.. _DBAL documentation: https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/index.html
+.. _DBAL documentation: https://www.doctrine-project.org/projects/doctrine-dbal/en/3.0/index.html
 .. _DBAL: https://www.doctrine-project.org/projects/dbal.html
 .. _Doctrine ORM: https://www.doctrine-project.org/projects/orm.html
-.. _Doctrine ORM documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/index.html
+.. _Doctrine ORM documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/3.0/index.html
 .. _hosted on GitHub: https://github.com/crate/crate-dbal
 .. _Object-Relational Mapper: https://www.doctrine-project.org/projects/orm.html
 .. _open source: https://en.wikipedia.org/wiki/Open-source_software


### PR DESCRIPTION
## About

This patch fixes a few broken links, which blocks CI runs on GH-133 and GH-134.
