### PR TITLE
Verify support on PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
+- Verified support on PHP 8.4
+
 2024/02/02 4.0.2
 ================
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB DBAL Driver
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-8.0%2C%208.1%2C%208.2%2C%208.3-green.svg
+.. image:: https://img.shields.io/badge/PHP-8.0%2C%208.1%2C%208.2%2C%208.3%2C%208.4-green.svg
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Supported PHP versions
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.0|^8.1|^8.2|^8.3",
+        "php": "^8.0|^8.1|^8.2|^8.3|^8.4",
         "doctrine/dbal": "^2",
         "crate/crate-pdo": "^2"
     },


### PR DESCRIPTION
## About
PHP 8.4 has been released on Nov 21, 2024.

- https://www.php.net/releases/8.4/
