### PR TITLE
remove page-local TOC

### DIFF
--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -4,11 +4,6 @@
 Compatibility
 =============
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
 .. _versions:
 
 Version notes

--- a/docs/appendices/index.rst
+++ b/docs/appendices/index.rst
@@ -9,7 +9,7 @@ Supplementary information for the CrateDB DBAL driver.
 .. rubric:: Table of contents
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    table-options
    data-types

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -4,11 +4,6 @@
 Connect to CrateDB
 ==================
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
 Authentication
 ==============
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -5,11 +5,6 @@ Getting started
 Learn how to install and get started with the :ref:`CrateDB DBAL driver
 <index>`.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
 Prerequisites
 =============
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ This driver also works with `Doctrine ORM`_, an `Object-Relational Mapper`_.
 .. rubric:: Table of contents
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    getting-started
    connect


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Remove redundant page-local TOC.

Part of  https://github.com/crate/tech-content/issues/140

## Preview
https://crate-dbal--138.org.readthedocs.build/en/138/