### PR TITLE
Replace use of `Crate\PDO\PDO` (deprecated) by `Crate\PDO\PDOCrateDB`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Unreleased
 
 - Verified support on PHP 8.4 and PHP 8.5
 - Reflection: Adjusted evaluation of column's ``is_nullable`` attribute for CrateDB >= 6.1
+- Dependencies: Replaced use of ``Crate\PDO\PDO`` (deprecated) by ``Crate\PDO\PDOCrateDB``
 
 2024/02/02 4.0.2
 ================

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": "^8.0|^8.1|^8.2|^8.3|^8.4|^8.5",
         "doctrine/dbal": "^2",
-        "crate/crate-pdo": "^2"
+        "crate/crate-pdo": "^2",
+        "ext-pdo": "*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Crate/DBAL/Driver/PDOCrate/PDOConnection.php
+++ b/src/Crate/DBAL/Driver/PDOCrate/PDOConnection.php
@@ -22,10 +22,10 @@
 
 namespace Crate\DBAL\Driver\PDOCrate;
 
-use Crate\PDO\PDO;
+use Crate\PDO\PDOCrateDB;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 
-class PDOConnection extends PDO implements ServerInfoAwareConnection
+class PDOConnection extends PDOCrateDB implements ServerInfoAwareConnection
 {
     /**
      * @param string $dsn
@@ -36,8 +36,8 @@ class PDOConnection extends PDO implements ServerInfoAwareConnection
     public function __construct($dsn, $user = null, $password = null, array $options = null)
     {
         parent::__construct($dsn, $user, $password, $options);
-        $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, CrateStatement::class);
-        $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->setAttribute(\PDO::ATTR_STATEMENT_CLASS, CrateStatement::class);
+        $this->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
     }
 
     /**

--- a/src/Crate/DBAL/Types/ArrayType.php
+++ b/src/Crate/DBAL/Types/ArrayType.php
@@ -22,7 +22,7 @@
 
 namespace Crate\DBAL\Types;
 
-use Crate\PDO\PDO;
+use Crate\PDO\PDOCrateDB;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -53,7 +53,7 @@ class ArrayType extends Type
      */
     public function getBindingType()
     {
-        return PDO::PARAM_ARRAY;
+        return PDOCrateDB::PARAM_ARRAY;
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)

--- a/src/Crate/DBAL/Types/MapType.php
+++ b/src/Crate/DBAL/Types/MapType.php
@@ -23,7 +23,7 @@
 namespace Crate\DBAL\Types;
 
 use Crate\DBAL\Platforms\CratePlatform;
-use Crate\PDO\PDO;
+use Crate\PDO\PDOCrateDB;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -59,7 +59,7 @@ class MapType extends Type
      */
     public function getBindingType()
     {
-        return PDO::PARAM_OBJECT;
+        return PDOCrateDB::PARAM_OBJECT;
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)

--- a/test/Crate/Test/DBAL/Functional/ConnectionTest.php
+++ b/test/Crate/Test/DBAL/Functional/ConnectionTest.php
@@ -22,7 +22,7 @@
 namespace Crate\Test\DBAL\Functional;
 
 use Crate\Test\DBAL\DBALFunctionalTestCase;
-use Crate\PDO\PDO;
+use Crate\PDO\PDOCrateDB;
 
 class ConnectionTestCase extends DBALFunctionalTestCase
 {
@@ -51,7 +51,7 @@ class ConnectionTestCase extends DBALFunctionalTestCase
         $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
         $this->assertEquals($auth[0], $conn->getUsername());
         $this->assertEquals($auth[1], $conn->getPassword());
-        $auth_attr = $conn->getWrappedConnection()->getAttribute(PDO::CRATE_ATTR_HTTP_BASIC_AUTH);
+        $auth_attr = $conn->getWrappedConnection()->getAttribute(PDOCrateDB::CRATE_ATTR_HTTP_BASIC_AUTH);
         $this->assertEquals($auth_attr, $auth);
     }
 


### PR DESCRIPTION
## About
Follow a deprecation warning issued by upstream `crate-pdo` package.

## References
- GH-141