### PR TITLE
Make `PDOConnection::__construct()` signature use explicit nullable type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Unreleased
 - Verified support on PHP 8.4 and PHP 8.5
 - Reflection: Adjusted evaluation of column's ``is_nullable`` attribute for CrateDB >= 6.1
 - Dependencies: Replaced use of ``Crate\PDO\PDO`` (deprecated) by ``Crate\PDO\PDOCrateDB``
+- Maintenance: Fixed ``PDOConnection::__construct()`` signature to use explicit nullable types
 
 2024/02/02 4.0.2
 ================

--- a/src/Crate/DBAL/Driver/PDOCrate/PDOConnection.php
+++ b/src/Crate/DBAL/Driver/PDOCrate/PDOConnection.php
@@ -31,9 +31,9 @@ class PDOConnection extends PDOCrateDB implements ServerInfoAwareConnection
      * @param string $dsn
      * @param string $user
      * @param string $password
-     * @param array $options
+     * @param array|null $options
      */
-    public function __construct($dsn, $user = null, $password = null, array $options = null)
+    public function __construct($dsn, $user = null, $password = null, ?array $options = null)
     {
         parent::__construct($dsn, $user, $password, $options);
         $this->setAttribute(\PDO::ATTR_STATEMENT_CLASS, CrateStatement::class);


### PR DESCRIPTION
## About
Fix a little deprecation warning.

## References
- GH-141