### PR TITLE
Maintenance: Verify support on PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php-version: [
+          '8.0',
+          '8.1',
+          '8.2',
+          '8.3',
+          '8.4',
+          '8.5',
+        ]
         cratedb-version: [ 'nightly' ]
         include:
           - os: 'ubuntu-latest'
-            php-version: '8.4'
+            php-version: '8.5'
             cratedb-version: '6.0.3'
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES for crate-dbal
 Unreleased
 ==========
 
-- Verified support on PHP 8.4
+- Verified support on PHP 8.4 and PHP 8.5
 - Reflection: Adjusted evaluation of column's ``is_nullable`` attribute for CrateDB >= 6.1
 
 2024/02/02 4.0.2

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB DBAL Driver
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-8.0%2C%208.1%2C%208.2%2C%208.3%2C%208.4-green.svg
+.. image:: https://img.shields.io/badge/PHP-8.0%2C%208.1%2C%208.2%2C%208.3%2C%208.4%2C%208.5-green.svg
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Supported PHP versions
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.0|^8.1|^8.2|^8.3|^8.4",
+        "php": "^8.0|^8.1|^8.2|^8.3|^8.4|^8.5",
         "doctrine/dbal": "^2",
         "crate/crate-pdo": "^2"
     },


### PR DESCRIPTION
- [PHP 8.5.0 RC4 available for testing](https://www.php.net/archive/2025.php#2025-11-06-1) (06 Nov 2025)
- [PHP 8.5: What's New and Changed](https://php.watch/versions/8.5)