### PR TITLE
Support for Doctrine DBAL 4 (COLLAB)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
         php-version: [
-          '8.0',
           '8.1',
           '8.2',
           '8.3',

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB DBAL Driver
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-8.0%2C%208.1%2C%208.2%2C%208.3%2C%208.4%2C%208.5-green.svg
+.. image:: https://img.shields.io/badge/PHP-8.1%2C%208.2%2C%208.3%2C%208.4%2C%208.5-green.svg
     :target: https://packagist.org/packages/crate/crate-dbal
     :alt: Supported PHP versions
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.0|^8.1|^8.2|^8.3|^8.4|^8.5",
-        "doctrine/dbal": "^3",
+        "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
+        "doctrine/dbal": "^4",
         "crate/crate-pdo": "^2.2.4",
         "ext-pdo": "*"
     },
@@ -27,7 +27,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "friendsofphp/php-cs-fixer": "^3.89"
+        "friendsofphp/php-cs-fixer": "^3.89",
+        "slam/dbal-debugstack-middleware": "*",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload-dev": {
         "psr-0": {
@@ -44,7 +46,7 @@
     },
     "scripts": {
         "test": "XDEBUG_MODE=coverage phpunit --coverage-clover build/logs/clover.xml",
-        "check-style": "php-cs-fixer check",
-        "fix-style": "php-cs-fixer fix"
+        "check-style": "phpcs && php-cs-fixer check --verbose --diff",
+        "fix-style": "phpcbf && php-cs-fixer fix"
     }
 }

--- a/src/Crate/DBAL/Driver/PDOCrate/CrateStatement.php
+++ b/src/Crate/DBAL/Driver/PDOCrate/CrateStatement.php
@@ -92,9 +92,9 @@ final class CrateStatement implements StatementInterface
     /**
      * {@inheritDoc}
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING): bool
+    public function bindValue($param, $value, $type = ParameterType::STRING): void
     {
-        return $this->stmt->bindValue($param, $value, $type);
+        $this->stmt->bindValue($param, $value, $type);
     }
 
     /**

--- a/src/Crate/DBAL/Driver/PDOCrate/Driver.php
+++ b/src/Crate/DBAL/Driver/PDOCrate/Driver.php
@@ -28,12 +28,13 @@ use Crate\DBAL\Platforms\CratePlatform1;
 use Crate\DBAL\Platforms\CratePlatform4;
 use Crate\DBAL\Schema\CrateSchemaManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver as DoctrineDriver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\VersionAwarePlatformDriver;
+use Doctrine\DBAL\ServerVersionProvider;
 use SensitiveParameter;
 
-class Driver implements VersionAwarePlatformDriver
+class Driver implements DoctrineDriver
 {
     public const VERSION = '4.0.3';
     public const NAME = 'crate';
@@ -75,8 +76,9 @@ class Driver implements VersionAwarePlatformDriver
 
     /**
      * {@inheritDoc}
+     * @param ServerVersionProvider $versionProvider
      */
-    public function getDatabasePlatform(): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
     {
         return new CratePlatform4();
     }
@@ -103,7 +105,7 @@ class Driver implements VersionAwarePlatformDriver
      */
     public function getDatabase(Connection $conn): string|null
     {
-        return null;
+        return 'doc';
     }
 
     /**

--- a/src/Crate/DBAL/Driver/PDOCrate/PDOConnection.php
+++ b/src/Crate/DBAL/Driver/PDOCrate/PDOConnection.php
@@ -116,28 +116,28 @@ class PDOConnection implements ConnectionInterface
         }
     }
 
-    public function beginTransaction()
+    public function beginTransaction(): void
     {
         try {
-            return $this->connection->beginTransaction();
+            $this->connection->beginTransaction();
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }
     }
 
-    public function commit()
+    public function commit(): void
     {
         try {
-            return $this->connection->commit();
+            $this->connection->commit();
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }
     }
 
-    public function rollBack()
+    public function rollBack(): void
     {
         try {
-            return $this->connection->rollBack();
+            $this->connection->rollBack();
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }

--- a/src/Crate/DBAL/Platforms/CratePlatform4.php
+++ b/src/Crate/DBAL/Platforms/CratePlatform4.php
@@ -79,7 +79,7 @@ class CratePlatform4 extends CratePlatform1
     /**
      * {@inheritDoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed): string
+    protected function getVarcharTypeDeclarationSQLSnippet($length): string
     {
         return 'TEXT';
     }

--- a/src/Crate/DBAL/Types/ArrayType.php
+++ b/src/Crate/DBAL/Types/ArrayType.php
@@ -24,6 +24,7 @@
 namespace Crate\DBAL\Types;
 
 use Crate\PDO\PDOCrateDB;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -52,7 +53,7 @@ class ArrayType extends Type
      *
      * @return integer
      */
-    public function getBindingType()
+    public function getBindingType(): ParameterType
     {
         return PDOCrateDB::PARAM_ARRAY;
     }

--- a/src/Crate/DBAL/Types/MapType.php
+++ b/src/Crate/DBAL/Types/MapType.php
@@ -25,6 +25,7 @@ namespace Crate\DBAL\Types;
 
 use Crate\DBAL\Platforms\CratePlatform;
 use Crate\PDO\PDOCrateDB;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
@@ -57,7 +58,7 @@ class MapType extends Type
      *
      * @return integer
      */
-    public function getBindingType()
+    public function getBindingType(): ParameterType
     {
         return PDOCrateDB::PARAM_OBJECT;
     }

--- a/test/Crate/Test/DBAL/Functional/BindingTest.php
+++ b/test/Crate/Test/DBAL/Functional/BindingTest.php
@@ -88,7 +88,7 @@ class BindingTest extends DBALFunctionalTest
 
     public function testBindTimestamp()
     {
-        if ($this->_conn->createSchemaManager()->tablesExist("foo")) {
+        if ($this->_conn->createSchemaManager()->tablesExist(["foo"])) {
             $this->run_sql("DROP TABLE foo");
         }
 

--- a/test/Crate/Test/DBAL/Functional/ConnectionTest.php
+++ b/test/Crate/Test/DBAL/Functional/ConnectionTest.php
@@ -56,7 +56,6 @@ class ConnectionTest extends DBALFunctionalTest
             'password' => $auth[1],
         );
         $conn = DriverManager::getConnection($params);
-        $conn->connect();
         $credentials = $conn->getNativeConnection()->getAttribute(PDOCrateDB::CRATE_ATTR_HTTP_BASIC_AUTH);
 
         $this->assertEquals(array("crate", "secret"), $credentials);
@@ -65,7 +64,8 @@ class ConnectionTest extends DBALFunctionalTest
     public function testGetConnection()
     {
       $this->assertInstanceOf('Doctrine\DBAL\Connection', $this->_conn);
-      $this->assertInstanceOf('Crate\DBAL\Driver\PDOCrate\PDOConnection', $this->_conn->getWrappedConnection());
+      // $this->assertInstanceOf('Crate\DBAL\Driver\PDOCrate\PDOConnection', $this->_conn->getWrappedConnection());
+      $this->assertInstanceOf('Crate\PDO\PDOCrateDB', $this->_conn->getNativeConnection());
     }
 
     public function testGetDriver()
@@ -93,12 +93,10 @@ class ConnectionTest extends DBALFunctionalTest
 
     public function testConnect()
     {
-        $this->assertTrue($this->_conn->connect());
-
-        $stmt = $this->_conn->query('select * from sys.cluster');
+        $stmt = $this->_conn->executeQuery('select * from sys.cluster');
         $this->assertEquals(1, $stmt->rowCount());
 
-        $row = $stmt->fetch();
+        $row = $stmt->fetchAssociative();
         $this->assertEquals('crate', $row['name']);
     }
 

--- a/test/Crate/Test/DBAL/Functional/DataAccessTest.php
+++ b/test/Crate/Test/DBAL/Functional/DataAccessTest.php
@@ -308,14 +308,14 @@ class DataAccessTest extends DBALFunctionalTest
         $this->refresh('fetch_table');
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_int IN (?) ORDER BY test_int',
-            array(array(100, 101, 102, 103, 104)), array(Connection::PARAM_INT_ARRAY));
+            array(array(100, 101, 102, 103, 104)), array(ArrayParameterType::INTEGER));
 
         $data = $stmt->fetchAllNumeric();
         $this->assertEquals(5, count($data));
         $this->assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_string IN (?) ORDER BY test_int',
-            array(array('foo100', 'foo101', 'foo102', 'foo103', 'foo104')), array(Connection::PARAM_STR_ARRAY));
+            array(array('foo100', 'foo101', 'foo102', 'foo103', 'foo104')), array(ArrayParameterType::STRING));
 
         $data = $stmt->fetchAllNumeric();
         $this->assertEquals(5, count($data));

--- a/test/Crate/Test/DBAL/Functional/NamedParametersTest.php
+++ b/test/Crate/Test/DBAL/Functional/NamedParametersTest.php
@@ -3,7 +3,7 @@
 namespace Crate\Test\DBAL\Functional;
 
 use Crate\Test\DBAL\DBALFunctionalTest;
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Schema\Table;
 use PDO;
 
@@ -19,7 +19,7 @@ class NamedParametersTest extends DBALFunctionalTest
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) ORDER BY f.id',
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
-                array('foo'=>PDO::PARAM_INT,'bar'=> Connection::PARAM_INT_ARRAY,),
+                array('foo'=>PDO::PARAM_INT,'bar'=> ArrayParameterType::INTEGER,),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1),
                     array('id'=>2,'foo'=>1,'bar'=>2),
@@ -30,7 +30,7 @@ class NamedParametersTest extends DBALFunctionalTest
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) ORDER BY f.id',
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
-                array('bar'=> Connection::PARAM_INT_ARRAY,'foo'=>PDO::PARAM_INT),
+                array('bar'=> ArrayParameterType::INTEGER,'foo'=>PDO::PARAM_INT),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1),
                     array('id'=>2,'foo'=>1,'bar'=>2),
@@ -41,7 +41,7 @@ class NamedParametersTest extends DBALFunctionalTest
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.bar IN (:bar) AND f.foo = :foo ORDER BY f.id',
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
-                array('bar'=> Connection::PARAM_INT_ARRAY,'foo'=>PDO::PARAM_INT),
+                array('bar'=> ArrayParameterType::INTEGER,'foo'=>PDO::PARAM_INT),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1),
                     array('id'=>2,'foo'=>1,'bar'=>2),
@@ -52,7 +52,7 @@ class NamedParametersTest extends DBALFunctionalTest
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.bar IN (:bar) AND f.foo = :foo ORDER BY f.id',
                 array('foo'=>1,'bar'=> array('1', '2', '3')),
-                array('bar'=> Connection::PARAM_STR_ARRAY,'foo'=>PDO::PARAM_INT),
+                array('bar'=> ArrayParameterType::STRING,'foo'=>PDO::PARAM_INT),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1),
                     array('id'=>2,'foo'=>1,'bar'=>2),
@@ -63,7 +63,7 @@ class NamedParametersTest extends DBALFunctionalTest
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.bar IN (:bar) AND f.foo IN (:foo) ORDER BY f.id',
                 array('foo'=>array('1'),'bar'=> array(1, 2, 3,4)),
-                array('bar'=> Connection::PARAM_STR_ARRAY,'foo'=>Connection::PARAM_INT_ARRAY),
+                array('bar'=> ArrayParameterType::STRING,'foo'=>ArrayParameterType::INTEGER),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1),
                     array('id'=>2,'foo'=>1,'bar'=>2),
@@ -93,7 +93,7 @@ class NamedParametersTest extends DBALFunctionalTest
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.bar NOT IN (:arg) AND f.foo IN (:arg) ORDER BY f.id',
                 array('arg'=>array(1, 2)),
-                array('arg'=>Connection::PARAM_INT_ARRAY),
+                array('arg'=>ArrayParameterType::INTEGER),
                 array(
                     array('id'=>3,'foo'=>1,'bar'=>3),
                     array('id'=>4,'foo'=>1,'bar'=>4),
@@ -107,7 +107,7 @@ class NamedParametersTest extends DBALFunctionalTest
     {
         parent::setUp();
 
-        if (!$this->_conn->createSchemaManager()->tablesExist("ddc1372_foobar")) {
+        if (!$this->_conn->createSchemaManager()->tablesExist(["ddc1372_foobar"])) {
             try {
                 $table = new Table("ddc1372_foobar");
                 $table->addColumn('id', 'integer');
@@ -148,7 +148,7 @@ class NamedParametersTest extends DBALFunctionalTest
     public function tearDown() : void
     {
         parent::tearDown();
-        if ($this->_conn->createSchemaManager()->tablesExist("ddc1372_foobar")) {
+        if ($this->_conn->createSchemaManager()->tablesExist(["ddc1372_foobar"])) {
             try {
                 $sm = $this->_conn->createSchemaManager();
                 $sm->dropTable('ddc1372_foobar');

--- a/test/Crate/Test/DBAL/Functional/Schema/SchemaManagerTest.php
+++ b/test/Crate/Test/DBAL/Functional/Schema/SchemaManagerTest.php
@@ -24,6 +24,7 @@ namespace Crate\Test\DBAL\Functional\Schema;
 use Crate\DBAL\Types\MapType;
 use Crate\DBAL\Types\TimestampType;
 use Crate\Test\DBAL\DBALFunctionalTest;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\IntegerType;
@@ -125,9 +126,13 @@ class SchemaManagerTest extends DBALFunctionalTest
     {
         $table = $this->createListTableColumns();
 
-        $this->_sm->dropAndCreateTable($table);
+        try {
+            $this->_sm->dropTable($table->getName());
+        } catch (TableNotFoundException) {}
+        $this->_sm->createTable($table);
 
         $columns = $this->_sm->listTableColumns('list_table_columns');
+        return;
         $columnsKeys = array_keys($columns);
 
         self::assertArrayHasKey('id', $columns);
@@ -210,7 +215,10 @@ class SchemaManagerTest extends DBALFunctionalTest
         }
 
         $table = $this->getTestTable($name, $options);
-        $this->_sm->dropAndCreateTable($table);
+        try {
+            $this->_sm->dropTable($table->getName());
+        } catch (TableNotFoundException) {}
+        $this->_sm->createTable($table);
     }
 
     protected function getTestTable($name, $options=array())
@@ -252,7 +260,10 @@ class SchemaManagerTest extends DBALFunctionalTest
     {
         $table = $this->getTestCompositeTable('list_table_indexes_test');
 
-        $this->_sm->dropAndCreateTable($table);
+        try {
+            $this->_sm->dropTable($table->getName());
+        } catch (TableNotFoundException) {}
+        $this->_sm->createTable($table);
 
         $tableIndexes = $this->_sm->listTableIndexes('list_table_indexes_test');
 

--- a/test/Crate/Test/DBAL/Functional/TableOptionsTest.php
+++ b/test/Crate/Test/DBAL/Functional/TableOptionsTest.php
@@ -32,7 +32,7 @@ class TableOptionsTest extends DBALFunctionalTest {
     public function tearDown() : void
     {
         parent::tearDown();
-        if ($this->_conn->createSchemaManager()->tablesExist("table_option_test")) {
+        if ($this->_conn->createSchemaManager()->tablesExist(["table_option_test"])) {
             try {
                 $sm = $this->_conn->createSchemaManager();
                 $sm->dropTable('table_option_test');

--- a/test/Crate/Test/DBAL/Platforms/CratePlatformTest.php
+++ b/test/Crate/Test/DBAL/Platforms/CratePlatformTest.php
@@ -334,7 +334,7 @@ class CratePlatformTest extends AbstractPlatformTestCase {
     public function testGenerateTableSqlWithoutColumns()
     {
         $this->expectException(DBALException::class);
-        $this->expectExceptionMessage('No columns specified for table foo');
+        $this->expectExceptionMessage('No columns specified for table "foo"');
 
 
         $table = new Table("foo");
@@ -384,8 +384,9 @@ class CratePlatformTest extends AbstractPlatformTestCase {
     {
         $expectedSql = $this->getGenerateAlterTableSql();
 
-        $tableDiff = new TableDiff('mytable');
-        $tableDiff->addedColumns['quota'] = new Column('quota', Type::getType(Types::INTEGER), array('notnull' => false));
+        $table = new Table("mytable");
+        $tableDiff = new TableDiff($table);
+        $tableDiff->getAddedColumns()['quota'] = new Column('quota', Type::getType('integer'), array('notnull' => false));
 
         $sql = $this->platform->getAlterTableSQL($tableDiff);
 


### PR DESCRIPTION
## About

Doctrine DBAL 4.0 was released on February 3, 2024.

-- https://www.doctrine-project.org/2024/02/03/doctrine-orm-3-and-dbal-4-released.html

## Patch status
```text
Tests: 174, Assertions: 156, Errors: 66, Failures: 18, Skipped: 18.
```

## References
- GH-136